### PR TITLE
Restore form styles lost during merge

### DIFF
--- a/style.css
+++ b/style.css
@@ -88,3 +88,20 @@ form h3 {
     margin-top: 15px;
 }
 
+.pdf-list {
+    margin-top: 20px;
+    padding: 0;
+}
+
+.pdf-list li {
+    margin-bottom: 10px;
+}
+
+.pdf-list li a {
+    color: #2a6ebb;
+    text-decoration: none;
+}
+
+.pdf-list li a:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- append `pdf-list` block at the end of `style.css`
- ensure `form` styles appear immediately before `pdf-list`

## Testing
- `git status --short`