### PR TITLE
Add missing VLQ‑1 domains

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,19 +189,84 @@
              <td><input type="radio" name="importance_friends" value="9"><label>9</label></td>
              <td><input type="radio" name="importance_friends" value="10"><label>10</label></td>
            </tr>
-           <tr>
-             <td title="Career, job or professional life">Work</td>
-             <td><input type="radio" name="importance_work" value="1" required><label>1</label></td>
-             <td><input type="radio" name="importance_work" value="2"><label>2</label></td>
-             <td><input type="radio" name="importance_work" value="3"><label>3</label></td>
-             <td><input type="radio" name="importance_work" value="4"><label>4</label></td>
-             <td><input type="radio" name="importance_work" value="5"><label>5</label></td>
-             <td><input type="radio" name="importance_work" value="6"><label>6</label></td>
-             <td><input type="radio" name="importance_work" value="7"><label>7</label></td>
-             <td><input type="radio" name="importance_work" value="8"><label>8</label></td>
-             <td><input type="radio" name="importance_work" value="9"><label>9</label></td>
-             <td><input type="radio" name="importance_work" value="10"><label>10</label></td>
-           </tr>
+          <tr>
+            <td title="Career, job or professional life">Work</td>
+            <td><input type="radio" name="importance_work" value="1" required><label>1</label></td>
+            <td><input type="radio" name="importance_work" value="2"><label>2</label></td>
+            <td><input type="radio" name="importance_work" value="3"><label>3</label></td>
+            <td><input type="radio" name="importance_work" value="4"><label>4</label></td>
+            <td><input type="radio" name="importance_work" value="5"><label>5</label></td>
+            <td><input type="radio" name="importance_work" value="6"><label>6</label></td>
+            <td><input type="radio" name="importance_work" value="7"><label>7</label></td>
+            <td><input type="radio" name="importance_work" value="8"><label>8</label></td>
+            <td><input type="radio" name="importance_work" value="9"><label>9</label></td>
+            <td><input type="radio" name="importance_work" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Learning, personal growth or academic goals">Education/Training</td>
+            <td><input type="radio" name="importance_education" value="1" required><label>1</label></td>
+            <td><input type="radio" name="importance_education" value="2"><label>2</label></td>
+            <td><input type="radio" name="importance_education" value="3"><label>3</label></td>
+            <td><input type="radio" name="importance_education" value="4"><label>4</label></td>
+            <td><input type="radio" name="importance_education" value="5"><label>5</label></td>
+            <td><input type="radio" name="importance_education" value="6"><label>6</label></td>
+            <td><input type="radio" name="importance_education" value="7"><label>7</label></td>
+            <td><input type="radio" name="importance_education" value="8"><label>8</label></td>
+            <td><input type="radio" name="importance_education" value="9"><label>9</label></td>
+            <td><input type="radio" name="importance_education" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Leisure activities and hobbies">Recreation</td>
+            <td><input type="radio" name="importance_recreation" value="1" required><label>1</label></td>
+            <td><input type="radio" name="importance_recreation" value="2"><label>2</label></td>
+            <td><input type="radio" name="importance_recreation" value="3"><label>3</label></td>
+            <td><input type="radio" name="importance_recreation" value="4"><label>4</label></td>
+            <td><input type="radio" name="importance_recreation" value="5"><label>5</label></td>
+            <td><input type="radio" name="importance_recreation" value="6"><label>6</label></td>
+            <td><input type="radio" name="importance_recreation" value="7"><label>7</label></td>
+            <td><input type="radio" name="importance_recreation" value="8"><label>8</label></td>
+            <td><input type="radio" name="importance_recreation" value="9"><label>9</label></td>
+            <td><input type="radio" name="importance_recreation" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Religious faith or spiritual practices">Spirituality</td>
+            <td><input type="radio" name="importance_spirituality" value="1" required><label>1</label></td>
+            <td><input type="radio" name="importance_spirituality" value="2"><label>2</label></td>
+            <td><input type="radio" name="importance_spirituality" value="3"><label>3</label></td>
+            <td><input type="radio" name="importance_spirituality" value="4"><label>4</label></td>
+            <td><input type="radio" name="importance_spirituality" value="5"><label>5</label></td>
+            <td><input type="radio" name="importance_spirituality" value="6"><label>6</label></td>
+            <td><input type="radio" name="importance_spirituality" value="7"><label>7</label></td>
+            <td><input type="radio" name="importance_spirituality" value="8"><label>8</label></td>
+            <td><input type="radio" name="importance_spirituality" value="9"><label>9</label></td>
+            <td><input type="radio" name="importance_spirituality" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Civic engagement or neighborhood involvement">Citizenship/Community Life</td>
+            <td><input type="radio" name="importance_community" value="1" required><label>1</label></td>
+            <td><input type="radio" name="importance_community" value="2"><label>2</label></td>
+            <td><input type="radio" name="importance_community" value="3"><label>3</label></td>
+            <td><input type="radio" name="importance_community" value="4"><label>4</label></td>
+            <td><input type="radio" name="importance_community" value="5"><label>5</label></td>
+            <td><input type="radio" name="importance_community" value="6"><label>6</label></td>
+            <td><input type="radio" name="importance_community" value="7"><label>7</label></td>
+            <td><input type="radio" name="importance_community" value="8"><label>8</label></td>
+            <td><input type="radio" name="importance_community" value="9"><label>9</label></td>
+            <td><input type="radio" name="importance_community" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Health, nutrition, exercise and general self-care">Physical Self-Care</td>
+            <td><input type="radio" name="importance_selfcare" value="1" required><label>1</label></td>
+            <td><input type="radio" name="importance_selfcare" value="2"><label>2</label></td>
+            <td><input type="radio" name="importance_selfcare" value="3"><label>3</label></td>
+            <td><input type="radio" name="importance_selfcare" value="4"><label>4</label></td>
+            <td><input type="radio" name="importance_selfcare" value="5"><label>5</label></td>
+            <td><input type="radio" name="importance_selfcare" value="6"><label>6</label></td>
+            <td><input type="radio" name="importance_selfcare" value="7"><label>7</label></td>
+            <td><input type="radio" name="importance_selfcare" value="8"><label>8</label></td>
+            <td><input type="radio" name="importance_selfcare" value="9"><label>9</label></td>
+            <td><input type="radio" name="importance_selfcare" value="10"><label>10</label></td>
+          </tr>
          </tbody>
        </table>
        
@@ -265,19 +330,84 @@
              <td><input type="radio" name="consistency_friends" value="9"><label>9</label></td>
              <td><input type="radio" name="consistency_friends" value="10"><label>10</label></td>
            </tr>
-           <tr>
-             <td title="Career, job or professional life">Work</td>
-             <td><input type="radio" name="consistency_work" value="1" required><label>1</label></td>
-             <td><input type="radio" name="consistency_work" value="2"><label>2</label></td>
-             <td><input type="radio" name="consistency_work" value="3"><label>3</label></td>
-             <td><input type="radio" name="consistency_work" value="4"><label>4</label></td>
-             <td><input type="radio" name="consistency_work" value="5"><label>5</label></td>
-             <td><input type="radio" name="consistency_work" value="6"><label>6</label></td>
-             <td><input type="radio" name="consistency_work" value="7"><label>7</label></td>
-             <td><input type="radio" name="consistency_work" value="8"><label>8</label></td>
-             <td><input type="radio" name="consistency_work" value="9"><label>9</label></td>
-             <td><input type="radio" name="consistency_work" value="10"><label>10</label></td>
-           </tr>
+          <tr>
+            <td title="Career, job or professional life">Work</td>
+            <td><input type="radio" name="consistency_work" value="1" required><label>1</label></td>
+            <td><input type="radio" name="consistency_work" value="2"><label>2</label></td>
+            <td><input type="radio" name="consistency_work" value="3"><label>3</label></td>
+            <td><input type="radio" name="consistency_work" value="4"><label>4</label></td>
+            <td><input type="radio" name="consistency_work" value="5"><label>5</label></td>
+            <td><input type="radio" name="consistency_work" value="6"><label>6</label></td>
+            <td><input type="radio" name="consistency_work" value="7"><label>7</label></td>
+            <td><input type="radio" name="consistency_work" value="8"><label>8</label></td>
+            <td><input type="radio" name="consistency_work" value="9"><label>9</label></td>
+            <td><input type="radio" name="consistency_work" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Learning, personal growth or academic goals">Education/Training</td>
+            <td><input type="radio" name="consistency_education" value="1" required><label>1</label></td>
+            <td><input type="radio" name="consistency_education" value="2"><label>2</label></td>
+            <td><input type="radio" name="consistency_education" value="3"><label>3</label></td>
+            <td><input type="radio" name="consistency_education" value="4"><label>4</label></td>
+            <td><input type="radio" name="consistency_education" value="5"><label>5</label></td>
+            <td><input type="radio" name="consistency_education" value="6"><label>6</label></td>
+            <td><input type="radio" name="consistency_education" value="7"><label>7</label></td>
+            <td><input type="radio" name="consistency_education" value="8"><label>8</label></td>
+            <td><input type="radio" name="consistency_education" value="9"><label>9</label></td>
+            <td><input type="radio" name="consistency_education" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Leisure activities and hobbies">Recreation</td>
+            <td><input type="radio" name="consistency_recreation" value="1" required><label>1</label></td>
+            <td><input type="radio" name="consistency_recreation" value="2"><label>2</label></td>
+            <td><input type="radio" name="consistency_recreation" value="3"><label>3</label></td>
+            <td><input type="radio" name="consistency_recreation" value="4"><label>4</label></td>
+            <td><input type="radio" name="consistency_recreation" value="5"><label>5</label></td>
+            <td><input type="radio" name="consistency_recreation" value="6"><label>6</label></td>
+            <td><input type="radio" name="consistency_recreation" value="7"><label>7</label></td>
+            <td><input type="radio" name="consistency_recreation" value="8"><label>8</label></td>
+            <td><input type="radio" name="consistency_recreation" value="9"><label>9</label></td>
+            <td><input type="radio" name="consistency_recreation" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Religious faith or spiritual practices">Spirituality</td>
+            <td><input type="radio" name="consistency_spirituality" value="1" required><label>1</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="2"><label>2</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="3"><label>3</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="4"><label>4</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="5"><label>5</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="6"><label>6</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="7"><label>7</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="8"><label>8</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="9"><label>9</label></td>
+            <td><input type="radio" name="consistency_spirituality" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Civic engagement or neighborhood involvement">Citizenship/Community Life</td>
+            <td><input type="radio" name="consistency_community" value="1" required><label>1</label></td>
+            <td><input type="radio" name="consistency_community" value="2"><label>2</label></td>
+            <td><input type="radio" name="consistency_community" value="3"><label>3</label></td>
+            <td><input type="radio" name="consistency_community" value="4"><label>4</label></td>
+            <td><input type="radio" name="consistency_community" value="5"><label>5</label></td>
+            <td><input type="radio" name="consistency_community" value="6"><label>6</label></td>
+            <td><input type="radio" name="consistency_community" value="7"><label>7</label></td>
+            <td><input type="radio" name="consistency_community" value="8"><label>8</label></td>
+            <td><input type="radio" name="consistency_community" value="9"><label>9</label></td>
+            <td><input type="radio" name="consistency_community" value="10"><label>10</label></td>
+          </tr>
+          <tr>
+            <td title="Health, nutrition, exercise and general self-care">Physical Self-Care</td>
+            <td><input type="radio" name="consistency_selfcare" value="1" required><label>1</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="2"><label>2</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="3"><label>3</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="4"><label>4</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="5"><label>5</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="6"><label>6</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="7"><label>7</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="8"><label>8</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="9"><label>9</label></td>
+            <td><input type="radio" name="consistency_selfcare" value="10"><label>10</label></td>
+          </tr>
          </tbody>
        </table>
        

--- a/script.js
+++ b/script.js
@@ -3,6 +3,20 @@
  * Handles core application logic, form validation, and data processing
  */
 
+// Standard VLQ-1 life domains used throughout the app
+const VLQ1_DOMAINS = [
+    'family',
+    'marriage',
+    'parenting',
+    'friends',
+    'work',
+    'education',
+    'recreation',
+    'spirituality',
+    'community',
+    'selfcare'
+];
+
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
     // Initialize navigation
@@ -279,18 +293,13 @@ function processVLQ1FormData() {
         timestamp: new Date().toISOString()
     };
 
-    // Process importance ratings
-    const importanceRadios = form.querySelectorAll('input[name^="importance_"]:checked');
-    importanceRadios.forEach(radio => {
-        const domain = radio.name.replace('importance_', '');
-        formData.importance[domain] = parseInt(radio.value);
-    });
+    // Capture ratings for every standard domain
+    VLQ1_DOMAINS.forEach(domain => {
+        const impInput = form.querySelector(`input[name="importance_${domain}"]:checked`);
+        const conInput = form.querySelector(`input[name="consistency_${domain}"]:checked`);
 
-    // Process consistency ratings
-    const consistencyRadios = form.querySelectorAll('input[name^="consistency_"]:checked');
-    consistencyRadios.forEach(radio => {
-        const domain = radio.name.replace('consistency_', '');
-        formData.consistency[domain] = parseInt(radio.value);
+        formData.importance[domain] = impInput ? parseInt(impInput.value) : null;
+        formData.consistency[domain] = conInput ? parseInt(conInput.value) : null;
     });
 
     return formData;
@@ -411,8 +420,8 @@ function showResults(formType, formData) {
  * @param {Object} formData - VLQ-1 form data
  */
 function generateVLQ1Visualizations(formData) {
-    // Get domain labels
-    const domains = Object.keys(formData.importance);
+    // Use predefined domain order for charts
+    const domains = VLQ1_DOMAINS;
     const labels = domains.map(domain => {
         return domain.charAt(0).toUpperCase() + domain.slice(1);
     });
@@ -606,7 +615,7 @@ function generateVLQ1Summary(formData) {
     const container = document.getElementById('summary-container');
     if (!container) return;
 
-    const domains = Object.keys(formData.importance);
+    const domains = VLQ1_DOMAINS;
     const highImportance = [];
     const highConsistency = [];
     const largeGaps = [];


### PR DESCRIPTION
## Summary
- add missing life-domain rows to VLQ‑1 tables
- track all ten domains with `VLQ1_DOMAINS`
- update `processVLQ1FormData` and visualizations to use the domain list

## Testing
- `npm test` *(fails: could not find package.json)*